### PR TITLE
Use HTTPS

### DIFF
--- a/src/pypi/client.coffee
+++ b/src/pypi/client.coffee
@@ -1,13 +1,13 @@
 xmlrpc = require 'xmlrpc'
 
-DEFAULT_URL = 'http://pypi.python.org/pypi'
+DEFAULT_URL = 'https://pypi.python.org/pypi'
 
 
 class Client
 
     constructor: (url=DEFAULT_URL) ->
         @url = url
-        @xmlrpcClient = xmlrpc.createClient @url
+        @xmlrpcClient = xmlrpc.createSecureClient @url
 
     callXmlrpc: (method, args, callback, onError) ->
         @xmlrpcClient.methodCall method, args, (error, value) ->


### PR DESCRIPTION
This fixes an `Error: Invalid XML-RPC message` that was occurring with the HTTP endpoint.
